### PR TITLE
feedback_message resizeable issue

### DIFF
--- a/css/jquery.feedback_me.css
+++ b/css/jquery.feedback_me.css
@@ -66,6 +66,7 @@
 .feedback_message {
 	display: block;
 	width: 340px;
+	resize: none;
 }
 
 .feedback_submit {


### PR DESCRIPTION
Added resize: none to the feedback_message class since the message resize event does not update the size of the feedback div.
