### PR TITLE
add jumbotron for bootstrap 3

### DIFF
--- a/js/jquery.feedback_me.js
+++ b/js/jquery.feedback_me.js
@@ -456,7 +456,7 @@ var fm = (function ($) {
 		if (fm_options.bootstrap === true) {
 			bootstrap_class = " fm_bootstrap ";
 			bootstrap_btn = " btn btn-primary ";
-			bootstrap_hero_unit = " hero-unit ";
+			bootstrap_hero_unit = " hero-unit jumbotron ";
 
 			fm_class = "";
 			jquery_class = "";


### PR DESCRIPTION
Bootstrap 3 renamed hero-unit to jumbotron, so now this uses both classes.